### PR TITLE
Dereference symbolic links to 'startlnp'

### DIFF
--- a/pack/startlnp
+++ b/pack/startlnp
@@ -1,5 +1,6 @@
 #!/bin/sh
-LNP_DIR=$(dirname "$0")
+LNP_PATH=$(readlink -f "$0")
+LNP_DIR=$(dirname "$LNP_PATH")
 cd "${LNP_DIR}"
 exename=$(basename "$0")
 t_bold="$(tput bold 2>/dev/null || printf '\033[1m')"


### PR DESCRIPTION
I like to link to game start scripts from a directory in my PATH. By adding 'readlink -f' the symlink is dereferenced, allowing the start script to tolerate this.
