### PR TITLE
Allow running script from any directory

### DIFF
--- a/pack/df_linux/distro_fixes.sh
+++ b/pack/df_linux/distro_fixes.sh
@@ -50,7 +50,7 @@ fi
 dlog "INFO" "Checking whether any distro specific fixes are required..."
 
 # find df bin relative to location of this shell script
-DF_BIN_LOCATION="$DF_DIR/libs/Dwarf_Fortress"
+DF_BIN_LOCATION="$PWD/libs/Dwarf_Fortress"
 
 if [ ! -f $DF_BIN_LOCATION ]; then
     dlog "WARN" "did not find df binary at $DF_BIN_LOCATION"


### PR DESCRIPTION
`distro_fixes.sh` would not find the Dwarf_Fortress executable if run from any folder other than the one in which the `df` and `dfhack` script and `distro_fixes.sh` was located in.
Only `./df` and `./dfhack` would make it work.
With this you can run `df` and `dfhack` from any folder level eg: `../../dfhack` or `herp/derp/df`
