### PR TITLE
Add Sabayon linux, a gentoo based, noob friendly distribution

### DIFF
--- a/pack/df_linux/distro_fixes.sh
+++ b/pack/df_linux/distro_fixes.sh
@@ -111,7 +111,7 @@ if [ x"$DF_ARCH" = x'32-bit' ] && [ x"$ARCH" = x'x86_64' ]; then
     if [ x"$OS" = x'fedora' ]; then
         find_zlib /usr/lib/libz.so.1 /usr/lib
     # Gentoo 2.2
-    elif [ x"$OS" = x'gentoo' ]; then
+    elif [ x"$OS" = x'gentoo' ] || [ x"$OS" = x'sabayon' ]; then
         find_zlib /lib32/libz.so.1 /lib32
     elif [ x"$OS" = x'arch' ] || [ x"$OS" = x'antergos' ] || [ x"$OS" = x'manjarolinux' ]; then
         find_zlib /usr/lib32/libz.so /usr/lib32


### PR DESCRIPTION
Sabayon linux (https://www.sabayon.org/) is a noob freiendly distrib based on gentoo linux.
This PR add support for it in `distro_fixes.sh`.

Tested on my sabayon it produces:

```
[distro_fixes] INFO Checking whether any ARCH/distro specific fixes are required...
[distro_fixes] INFO OS: Sabayon
[distro_fixes] INFO ARCH: x86_64
[distro_fixes] INFO VER: n/a
[distro_fixes] INFO DF_ARCH: 32-bit
[distro_fixes] INFO DF_BIN_LOCATION: /home/tychota/.bin/dwarf_fortress/df_linux/libs/Dwarf_Fortress
[distro_fixes] INFO 32 bit df on Sabayon/64bit detected
[distro_fixes] INFO Setting LD_PRELOAD to /lib32/libz.so.1
[distro_fixes] INFO Done
Gtk-Message: Failed to load module "pk-gtk-module"
Sound devices available:
OpenAL Soft
Picking OpenAL Soft. If your desired device was missing, make sure you have the appropriate 32-bit libraries installed. If you wanted a different device, configure ~/.openalrc appropriately.
Perfect OpenAL context attributes GET
Loading bindings from data/init/interface.txt
Resetting textures
```
