### PR TITLE
Add path to `find_libz()` on 64bit distros

### DIFF
--- a/pack/df_linux/distro_fixes.sh
+++ b/pack/df_linux/distro_fixes.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# This script checks the system for ARCH and disto details
+# This script checks the system for ARCH and distro details
 # and sets up env variables as workaround for use by the
 # df/dfhack scripts.
 
@@ -23,7 +23,7 @@ dlog() {
 }
 
 find_zlib() {
-    for hint in "$@" /usr/lib32 /lib32 /usr/lib/i386-linux-gnu /usr/lib/mesa-diverted/i386-linux-gnu /usr/lib ; do
+    for hint in "$@" /usr/lib32 /lib32 /usr/lib/i386-linux-gnu /usr/lib/mesa-diverted/i386-linux-gnu /usr/lib /lib/x86_64-linux-gnu ; do
         if [ -f "$hint" ]; then
             ZLIB_PATH="$hint"
             break


### PR DESCRIPTION
Add `/lib/x86_64-linux-gnu` to paths that `find_zlib()` looks up. And one typo.